### PR TITLE
[ARCH] Use a generic interface as response type

### DIFF
--- a/src/common/interfaces/response.ts
+++ b/src/common/interfaces/response.ts
@@ -1,0 +1,5 @@
+export interface IResult<T = Record<string, unknown>> {
+  status: 'OK' | 'NOT OK';
+  error?: string;
+  result: T | T[];
+}


### PR DESCRIPTION
We got to have a response interface type in-order to maintain strict typing of the code. 
This makes sure that we wouldn't send unstructured data. 